### PR TITLE
Problem: loading extension library fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Daniel Fagnan <dnfagnan@gmail.com>",
 
 [lib]
 name = "postgres_extension"
-crate-type = ["dylib"]
+crate-type = ["rlib"]
 
 [dependencies]
 libc = "*"

--- a/examples/is_zero/Cargo.toml
+++ b/examples/is_zero/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Daniel Fagnan <dnfagnan@gmail.com>"]
 
 [lib]
 name = "is_zero"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 
 [dependencies.postgres_extension]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Daniel Fagnan <dnfagnan@gmail.com>",
 
 [lib]
 name = "postgres_extension_macros"
-crate-type = ["dylib"]
+crate-type = ["rlib"]


### PR DESCRIPTION
```
ERROR:  could not load library "examples/is_zero/target/release/libis_zero.dylib":
dlopen(examples/is_zero/target/release/libis_zero.dylib, 10): Library not loaded: @rpath/libstd-34de3979baa7a8ad.dylib
```

Solution: currently, the library is built as a dylib, and therefore does
not bundle Rust libraries; changing the target extension to cdylib crate
type and the main library to rlib alleviates the problem.